### PR TITLE
fix: Panic on nil Call.Method

### DIFF
--- a/passes/bodyclose/bodyclose.go
+++ b/passes/bodyclose/bodyclose.go
@@ -325,7 +325,7 @@ func (r *runner) calledInFunc(f *ssa.Function, called bool) bool {
 								}
 								for _, vref := range vrefs {
 									if c, ok := vref.(*ssa.Call); ok {
-										if c.Call.Method.Name() == closeMethod {
+										if c.Call.Method != nil && c.Call.Method.Name() == closeMethod {
 											return !called
 										}
 									}


### PR DESCRIPTION
Fix a panic caused by using a nil Call.Method.

Fixes https://github.com/golangci/golangci-lint/issues/733